### PR TITLE
Add some improvements to the error reporting and the command line args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,7 @@ fn main() -> Result<()> {
     let app = App::new("machlist")
         .arg(
             Arg::with_name(ARG_VERBOSE)
+                .global(true)
                 .help("Increase client verbosity (use multiple times to increase)")
                 .multiple(true)
                 .short("v"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn machlist_local() -> PathBuf {
 fn user_host(user: Option<&str>, host: &str) -> String {
     match user {
         Some(u) => format!("{}@{}", u, host),
-        None => format!("{}", host),
+        None => host.to_string(),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ impl Resource {
     pub fn get_target_env(&self, target_env: &str) -> Result<&EnvironmentDef> {
         self.server
             .get(target_env)
-            .ok_or(anyhow!("cannot find specified target environment"))
+            .ok_or_else(|| anyhow!("cannot find specified target environment"))
     }
 
     pub fn get_username(&self) -> Result<Option<String>> {
@@ -100,7 +100,7 @@ impl EnvironmentDef {
     pub fn get_machine(&self, machine_name: &str) -> Result<&ServerDef> {
         self.0
             .get(machine_name)
-            .ok_or(anyhow!("cannot find {}", machine_name))
+            .ok_or_else(|| anyhow!("cannot find {}", machine_name))
     }
 
     pub fn list_non_proxies(&self) -> impl Iterator<Item = (&String, &ServerDef)> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::{App, Arg, SubCommand};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -85,7 +85,9 @@ impl Resource {
             None => Ok(None),
             Some(u) => {
                 if let Some(env_name) = u.strip_prefix("env:") {
-                    Ok(Some(std::env::var(env_name)?))
+                    Ok(Some(std::env::var(env_name).with_context(|| {
+                        format!("Cannot find environment variable {}", env_name)
+                    })?))
                 } else {
                     Ok(Some(u.clone()))
                 }


### PR DESCRIPTION
* the default resource file is now set at the `clap` level so we don't have to handle an `Option<Path>` later in the code
also now the default value appears in the help message
* the missing environment variables are displayed on error report
* `-r` can be set anywhere in the command line arguments (the option is now global)
* `-v` can be set anywhere in the command line arguments (the option is now global)

